### PR TITLE
Re-add crawling bookmarks

### DIFF
--- a/src/ao3/comments.py
+++ b/src/ao3/comments.py
@@ -115,12 +115,7 @@ class Comments(object):
             soup = BeautifulSoup(req.text, features='html.parser')
             for li_tag in soup.findAll('li',attrs={'class': 'comment'}):
                 try:
-<<<<<<< HEAD
                     yield self.parsecomment(li_tag)
-=======
-                    yield parsecomment(li_tag)
-
->>>>>>> 93330be5ba884db3eb99f79ef470af5025f15748
                 except AttributeError:
                     #deleted comment only has text
                     if "Previous comment deleted" in str(li_tag):

--- a/src/ao3/users.py
+++ b/src/ao3/users.py
@@ -1,11 +1,12 @@
 from datetime import datetime
-import collections
 import itertools
 import re
 import time
 
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup
 import requests
+
+from .works import Work
 
 
 class User(object):
@@ -36,6 +37,103 @@ class User(object):
 
     def __repr__(self):
         return '%s(username=%r)' % (type(self).__name__, self.username)
+
+    def bookmarks_ids(self):
+        """
+        Returns a list of the user's bookmarks' ids. Ignores external work bookmarks.
+        User must be logged in to see private bookmarks.
+        """
+
+        api_url = (
+            'https://archiveofourown.org/users/%s/bookmarks?page=%%d'
+            % self.username)
+
+        bookmarks = []
+
+        num_works = 0
+        for page_no in itertools.count(start=1):
+            print("Finding page: \t" + str(page_no) + " of bookmarks. \t" + str(num_works) + " bookmarks ids found.")
+
+            req = self.sess.get(api_url % page_no)
+            soup = BeautifulSoup(req.text, features='html.parser')
+
+            # The entries are stored in a list of the form:
+            #
+            #     <ol class="bookmark index group">
+            #       <li id="bookmark_12345" class="bookmark blurb group" role="article">
+            #         ...
+            #       </li>
+            #       <li id="bookmark_67890" class="bookmark blurb group" role="article">
+            #         ...
+            #       </li>
+            #       ...
+            #     </o
+
+            ol_tag = soup.find('ol', attrs={'class': 'bookmark'})
+
+
+            for li_tag in ol_tag.findAll('li', attrs={'class': 'blurb'}):
+                num_works = num_works + 1
+                try:
+                    # <h4 class="heading">
+                    #     <a href="/works/12345678">Work Title</a>
+                    #     <a href="/users/authorname/pseuds/authorpseud" rel="author">Author Name</a>
+                    # </h4>
+
+                    for h4_tag in li_tag.findAll('h4', attrs={'class': 'heading'}):
+                        for link in h4_tag.findAll('a'):
+                            if ('works' in link.get('href')) and not ('external_works' in link.get('href')):
+                                work_id = link.get('href').replace('/works/', '')
+                                bookmarks.append(work_id)
+                except KeyError:
+                    # A deleted work shows up as
+                    #
+                    #      <li class="deleted reading work blurb group">
+                    #
+                    # There's nothing that we can do about that, so just skip
+                    # over it.
+                    if 'deleted' in li_tag.attrs['class']:
+                        pass
+                    else:
+                        raise
+
+
+            # The pagination button at the end of the page is of the form
+            #
+            #     <li class="next" title="next"> ... </li>
+            #
+            # If there's another page of results, this contains an <a> tag
+            # pointing to the next page.  Otherwise, it contains a <span>
+            # tag with the 'disabled' class.
+            try:
+                next_button = soup.find('li', attrs={'class': 'next'})
+                if next_button.find('span', attrs={'class': 'disabled'}):
+                    break
+            except:
+                # In case of absence of "next"
+                break
+
+        return bookmarks
+
+    def bookmarks(self):
+        """
+        Returns a list of the user's bookmarks as Work objects.
+        Takes forever.
+        User must be logged in to see private bookmarks.
+        """
+
+        bookmark_total = 0
+        bookmark_ids = self.bookmarks_ids()
+        bookmarks = []
+
+        for bookmark_id in bookmark_ids:
+            work = Work(bookmark_id, self.sess)
+            bookmarks.append(work)
+
+            bookmark_total = bookmark_total + 1
+            # print (str(bookmark_total) + "\t bookmarks found.")
+
+        return bookmarks
 
     def reading_history(self):
         """Returns a list of articles in the user's reading history.

--- a/src/ao3/users.py
+++ b/src/ao3/users.py
@@ -57,6 +57,12 @@ class User(object):
             req = self.sess.get(api_url % page_no)
             soup = BeautifulSoup(req.text, features='html.parser')
 
+            #if timeout, wait and try again
+            while len(req.text) < 20 and "Retry later" in req.text:
+                print("timeout... waiting 3 mins and trying again")
+                time.sleep(180)
+                req = self.sess.get(api_url % page_no)
+
             # The entries are stored in a list of the form:
             #
             #     <ol class="bookmark index group">


### PR DESCRIPTION
Crawling a user's own bookmarks was removed in https://github.com/ladyofthelog/ao3/commit/a5cff304ec3aae78507f172b06d2a83145e77309, but I needed this functionality for my use of the library, so I've added it back in in my fork and thought I'd make a PR to re-add it here while I was at it. Hope this isn't presumptuous.

This PR just adds back the code that was deleted, as well as retrying after 3 minutes if we get the `Retry later` response from AO3 (same as in the `reading_history` method).